### PR TITLE
Factor CRLiteKey out of CRLiteQuery

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "clubcard-crlite"
 authors = ["John M. Schanck <jschanck@mozilla.com>"]
-version = "0.2.2"
+version = "0.3.0"
 license = "MPL-2.0"
 repository = "https://github.com/mozilla/clubcard-crlite/"
 description = "An instantiation of Clubcard for use in CRLite"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ description = "An instantiation of Clubcard for use in CRLite"
 edition = "2021"
 
 [dependencies]
-base64 = "0.22"
+base64 = "0.21"
 bincode = "1.3"
 clubcard = "0.3"
 rand = { version = "0.8", optional = true }

--- a/examples/inspect.rs
+++ b/examples/inspect.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use clubcard_crlite::CRLiteClubcard;
-use sha2::{Digest, Sha256};
 use std::env::args;
 use std::path::PathBuf;
 use std::process::ExitCode;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,4 +6,4 @@
 pub mod builder;
 
 mod query;
-pub use query::{CRLiteClubcard, CRLiteCoverage, CRLiteQuery, CRLiteStatus};
+pub use query::{CRLiteClubcard, CRLiteCoverage, CRLiteKey, CRLiteQuery, CRLiteStatus};

--- a/src/query.rs
+++ b/src/query.rs
@@ -138,7 +138,7 @@ impl AsRef<Clubcard<W, CRLiteCoverage, ()>> for CRLiteClubcard {
 
 impl std::fmt::Display for CRLiteClubcard {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        writeln!(f, "{}", self.0);
+        writeln!(f, "{}", self.0)?;
         writeln!(f, "{:=^80}", " Coverage ")?;
         writeln!(
             f,


### PR DESCRIPTION
Previously we performed the `sha256(issuer_spki_hash || serial)` computation inside of `CRLiteQuery::as_query`. This was wasteful, as we construct a CRLiteQuery for each SCT timestamp in `CRLiteClubcard::contains`. Worse yet, in the case of delta updates, the number of hash calls would grow as the product of the number of SCTs and the number of clubcards.

This factors a `CRLiteKey` type out of `CRLiteQuery` so that the hash evaluation can be reused.

This PR also fixes some compiler warnings and clippy lints and downgrades base64 to match the version in mozilla-central.