### PR TITLE
Encode min timestamp in metadata even when min entry is zero

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "clubcard-crlite"
 authors = ["John M. Schanck <jschanck@mozilla.com>"]
-version = "0.3.0"
+version = "0.3.1"
 license = "MPL-2.0"
 repository = "https://github.com/mozilla/clubcard-crlite/"
 description = "An instantiation of Clubcard for use in CRLite"

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -61,7 +61,7 @@ impl CRLiteCoverage {
                 _ => continue,
             };
             let min_covered = if entry.MinEntry == 0 {
-                0
+                entry.MinTimestamp
             } else {
                 entry.MinTimestamp + entry.MMD
             };


### PR DESCRIPTION
This aligns the metadata with what's stored in remote settings for cascades. It won't change our behavior when the timestamp passed to `in_universe` is from an actual SCT.