### PR TITLE
Fix a lifetime issue in `CRLiteClubcard::contains`

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -242,7 +242,7 @@ impl CRLiteClubcard {
 
     pub fn contains<'a>(
         &self,
-        key: &'a CRLiteKey<'a>,
+        key: &CRLiteKey<'a>,
         timestamps: impl Iterator<Item = (&'a LogId, Timestamp)>,
     ) -> CRLiteStatus {
         for (log_id, timestamp) in timestamps {


### PR DESCRIPTION
`CRLiteClubcard::contains` requires its `key` argument to have the same lifetime as the constituent references and references returned by the `timestamps` iterator, which is unnecessary and leads to an annoying issue when trying to wrap the function, demonstrated by [this](https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=f8c5f24bdb3116e8dc1163256d50b2b4) code sample.