### PR TITLE
ci: remove semver compatibility checks

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,14 +49,3 @@ jobs:
       - run: cargo doc --locked --all-features --no-deps --document-private-items
         env:
           RUSTDOCFLAGS: -Dwarnings
-
-  semver:
-    name: Check semver compatibility
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Check semver
-        uses: obi1kenobi/cargo-semver-checks-action@v2


### PR DESCRIPTION
Apparently the mozilla org has an Actions whitelist that prevents this from being run. Remove it for now, as I don't have any insight on how to get this into the whitelist, and I'm not sure pursuing that is worth it?