### PR TITLE
Use newtypes instead of type aliases

### DIFF
--- a/examples/query.rs
+++ b/examples/query.rs
@@ -2,11 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use clubcard_crlite::{CRLiteClubcard, CRLiteKey, CRLiteStatus};
-use sha2::{Digest, Sha256};
 use std::env::args;
 use std::path::PathBuf;
 use std::process::ExitCode;
+
+use clubcard_crlite::{CRLiteClubcard, CRLiteKey, CRLiteStatus, IssuerSpkiHash, LogId, Timestamp};
+use sha2::{Digest, Sha256};
 use x509_parser::prelude::*;
 
 fn read_as_der(path: &PathBuf) -> Result<Vec<u8>, std::io::Error> {
@@ -85,11 +86,16 @@ fn main() -> std::process::ExitCode {
         return ExitCode::FAILURE;
     };
 
-    let issuer_spki_hash: [u8; 32] = Sha256::digest(issuer.tbs_certificate.subject_pki.raw).into();
+    let issuer_spki_hash =
+        IssuerSpkiHash(Sha256::digest(issuer.tbs_certificate.subject_pki.raw).into());
     let serial = cert.tbs_certificate.raw_serial();
     let key = CRLiteKey::new(&issuer_spki_hash, serial);
 
-    match filter.contains(&key, scts.iter().map(|sct| (sct.id.key_id, sct.timestamp))) {
+    match filter.contains(
+        &key,
+        scts.iter()
+            .map(|sct| (LogId(*sct.id.key_id), Timestamp(sct.timestamp))),
+    ) {
         CRLiteStatus::Good => println!("Good"),
         CRLiteStatus::Revoked => println!("Revoked"),
         CRLiteStatus::NotEnrolled | CRLiteStatus::NotCovered => println!("Unknown"),

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -2,7 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::query::{CRLiteCoverage, CRLiteKey, CRLiteQuery};
+use crate::query::{
+    CRLiteCoverage, CRLiteKey, CRLiteQuery, IssuerSpkiHash, LogId, Timestamp, TimestampInterval,
+};
 use clubcard::{AsQuery, Equation, Filterable};
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -64,14 +66,14 @@ impl CRLiteCoverage {
             let Some(entry_mmd_ms) = entry.MMD.checked_mul(1000) else {
                 continue;
             };
-            let min_covered = if entry.MinEntry == 0 {
+            let low = Timestamp(if entry.MinEntry == 0 {
                 entry.MinTimestamp
             } else {
                 entry.MinTimestamp + entry_mmd_ms
-            };
-            let max_covered = entry.MaxTimestamp.saturating_sub(entry_mmd_ms);
-            if min_covered < max_covered {
-                coverage.insert(log_id, (min_covered, max_covered));
+            });
+            let high = Timestamp(entry.MaxTimestamp.saturating_sub(entry_mmd_ms));
+            if low < high {
+                coverage.insert(LogId(log_id), TimestampInterval { low, high });
             }
         }
         CRLiteCoverage(coverage)
@@ -80,7 +82,7 @@ impl CRLiteCoverage {
 
 pub struct CRLiteBuilderItem {
     /// issuer spki hash
-    issuer: [u8; 32],
+    issuer: IssuerSpkiHash,
     /// serial number. TODO: smallvec?
     serial: Vec<u8>,
     /// revocation status
@@ -88,7 +90,7 @@ pub struct CRLiteBuilderItem {
 }
 
 impl CRLiteBuilderItem {
-    pub fn revoked(issuer: [u8; 32], serial: Vec<u8>) -> Self {
+    pub fn revoked(issuer: IssuerSpkiHash, serial: Vec<u8>) -> Self {
         Self {
             issuer,
             serial,
@@ -96,7 +98,7 @@ impl CRLiteBuilderItem {
         }
     }
 
-    pub fn not_revoked(issuer: [u8; 32], serial: Vec<u8>) -> Self {
+    pub fn not_revoked(issuer: IssuerSpkiHash, serial: Vec<u8>) -> Self {
         Self {
             issuer,
             serial,
@@ -113,7 +115,7 @@ impl AsQuery<4> for CRLiteBuilderItem {
     }
 
     fn block(&self) -> &[u8] {
-        &self.issuer
+        &self.issuer.0
     }
 
     fn discriminant(&self) -> &[u8] {
@@ -144,8 +146,10 @@ mod tests {
         for (i, n) in subset_sizes.iter().enumerate() {
             let mut r = clubcard_builder.new_approx_builder(&[i as u8; 32]);
             for j in 0usize..*n {
-                let eq = CRLiteBuilderItem::revoked([i as u8; 32], j.to_le_bytes().to_vec());
-                r.insert(eq);
+                r.insert(CRLiteBuilderItem::revoked(
+                    IssuerSpkiHash([i as u8; 32]),
+                    j.to_le_bytes().to_vec(),
+                ));
             }
             r.set_universe_size(universe_size);
             approx_builders.push(r)
@@ -167,12 +171,17 @@ mod tests {
         for (i, n) in subset_sizes.iter().enumerate() {
             let mut r = clubcard_builder.new_exact_builder(&[i as u8; 32]);
             for j in 0usize..universe_size {
-                let item = if j < *n {
-                    CRLiteBuilderItem::revoked([i as u8; 32], j.to_le_bytes().to_vec())
+                r.insert(if j < *n {
+                    CRLiteBuilderItem::revoked(
+                        IssuerSpkiHash([i as u8; 32]),
+                        j.to_le_bytes().to_vec(),
+                    )
                 } else {
-                    CRLiteBuilderItem::not_revoked([i as u8; 32], j.to_le_bytes().to_vec())
-                };
-                r.insert(item);
+                    CRLiteBuilderItem::not_revoked(
+                        IssuerSpkiHash([i as u8; 32]),
+                        j.to_le_bytes().to_vec(),
+                    )
+                });
             }
             exact_builders.push(r)
         }
@@ -187,7 +196,13 @@ mod tests {
         clubcard_builder.collect_exact_ribbons(exact_ribbons);
 
         let mut log_coverage = HashMap::new();
-        log_coverage.insert([0u8; 32], (0u64, u64::MAX));
+        log_coverage.insert(
+            LogId([0u8; 32]),
+            TimestampInterval {
+                low: Timestamp(0),
+                high: Timestamp(u64::MAX),
+            },
+        );
 
         let clubcard = clubcard_builder.build::<CRLiteQuery>(CRLiteCoverage(log_coverage), ());
         println!("{}", clubcard);
@@ -208,7 +223,7 @@ mod tests {
         let mut included = 0;
         let mut excluded = 0;
         for i in 0..subset_sizes.len() {
-            let issuer = [i as u8; 32];
+            let issuer = IssuerSpkiHash([i as u8; 32]);
             for j in 0..universe_size {
                 let serial = j.to_le_bytes();
                 let key = CRLiteKey::new(&issuer, &serial);
@@ -224,13 +239,13 @@ mod tests {
         assert!(sum_universe_sizes - sum_subset_sizes == excluded);
 
         // Test that querying a serial from a never-before-seen issuer results in a non-member return.
-        let issuer = [subset_sizes.len() as u8; 32];
+        let issuer = IssuerSpkiHash([subset_sizes.len() as u8; 32]);
         let serial = 0usize.to_le_bytes();
         let key = CRLiteKey::new(&issuer, &serial);
         assert!(!clubcard.unchecked_contains(&CRLiteQuery::new(&key, None)));
 
         assert!(!subset_sizes.is_empty() && subset_sizes[0] > 0 && subset_sizes[0] < universe_size);
-        let issuer = [0u8; 32];
+        let issuer = IssuerSpkiHash([0u8; 32]);
         let revoked_serial = 0usize.to_le_bytes();
         let nonrevoked_serial = (universe_size - 1).to_le_bytes();
 
@@ -244,23 +259,21 @@ mod tests {
 
         // Test that calling contains() with a timestamp in a covered interval results in a
         // Member return.
-        let log_id = [0u8; 32];
-        let timestamp = (&log_id, 100);
-        let query = CRLiteQuery::new(&revoked_serial_key, Some(timestamp));
+        let log_id = LogId([0u8; 32]);
+        let timestamp = Timestamp(100);
+        let query = CRLiteQuery::new(&revoked_serial_key, Some((log_id, timestamp)));
         assert!(matches!(clubcard.contains(&query), Membership::Member));
 
         // Test that calling contains() without a timestamp in a covered interval results in a
         // Member return.
-        let timestamp = (&log_id, 100);
         let nonrevoked_serial_key = CRLiteKey::new(&issuer, &nonrevoked_serial);
-        let query = CRLiteQuery::new(&nonrevoked_serial_key, Some(timestamp));
+        let query = CRLiteQuery::new(&nonrevoked_serial_key, Some((log_id, timestamp)));
         assert!(matches!(clubcard.contains(&query), Membership::Nonmember));
 
         // Test that calling contains() without a timestamp in a covered interval results in a
         // Member return.
-        let log_id = [1u8; 32];
-        let timestamp = (&log_id, 100);
-        let query = CRLiteQuery::new(&revoked_serial_key, Some(timestamp));
+        let log_id = LogId([1u8; 32]);
+        let query = CRLiteQuery::new(&revoked_serial_key, Some((log_id, timestamp)));
         assert!(matches!(
             clubcard.contains(&query),
             Membership::NotInUniverse

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,4 +6,7 @@
 pub mod builder;
 
 mod query;
-pub use query::{CRLiteClubcard, CRLiteCoverage, CRLiteKey, CRLiteQuery, CRLiteStatus};
+pub use query::{
+    CRLiteClubcard, CRLiteCoverage, CRLiteKey, CRLiteQuery, CRLiteStatus, IssuerSpkiHash, LogId,
+    Timestamp, TimestampInterval,
+};

--- a/src/query.rs
+++ b/src/query.rs
@@ -2,24 +2,35 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use base64::Engine;
-use clubcard::{
-    ApproximateSizeOf, AsQuery, Clubcard, ClubcardIndex, Equation, Membership, Queryable,
-};
-use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 use std::cmp::max;
 use std::collections::HashMap;
 use std::error::Error;
 use std::fmt;
 use std::mem::size_of;
 
+use base64::Engine;
+use clubcard::{
+    ApproximateSizeOf, AsQuery, Clubcard, ClubcardIndex, Equation, Membership, Queryable,
+};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
 const W: usize = 4;
 
-type IssuerSpkiHash = [u8; 32];
-type LogId = [u8; 32];
-type Timestamp = u64;
-type TimestampInterval = (Timestamp, Timestamp);
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct IssuerSpkiHash(pub [u8; 32]);
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct LogId(pub [u8; 32]);
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Ord, PartialOrd, PartialEq, Serialize)]
+pub struct Timestamp(pub u64);
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+pub struct TimestampInterval {
+    pub low: Timestamp,
+    pub high: Timestamp,
+}
 
 #[derive(Serialize, Deserialize)]
 pub struct CRLiteCoverage(pub(crate) HashMap<LogId, TimestampInterval>);
@@ -39,10 +50,11 @@ pub struct CRLiteKey<'a> {
 
 impl<'a> CRLiteKey<'a> {
     pub fn new(issuer: &'a IssuerSpkiHash, serial: &'a [u8]) -> CRLiteKey<'a> {
-        let mut issuer_serial_hash = [0u8; 32];
         let mut hasher = Sha256::new();
-        hasher.update(issuer);
+        hasher.update(issuer.0);
         hasher.update(serial);
+
+        let mut issuer_serial_hash = [0u8; 32];
         hasher.finalize_into((&mut issuer_serial_hash).into());
         CRLiteKey {
             issuer,
@@ -55,18 +67,21 @@ impl<'a> CRLiteKey<'a> {
 #[derive(Clone, Debug)]
 pub struct CRLiteQuery<'a> {
     pub(crate) key: &'a CRLiteKey<'a>,
-    pub(crate) log_timestamp: Option<(&'a LogId, Timestamp)>,
+    pub(crate) log_timestamp: Option<(LogId, Timestamp)>,
 }
 
 impl<'a> CRLiteQuery<'a> {
-    pub fn new(key: &'a CRLiteKey<'a>, log_timestamp: Option<(&'a LogId, u64)>) -> CRLiteQuery<'a> {
+    pub fn new(
+        key: &'a CRLiteKey<'a>,
+        log_timestamp: Option<(LogId, Timestamp)>,
+    ) -> CRLiteQuery<'a> {
         CRLiteQuery { key, log_timestamp }
     }
 }
 
 impl AsQuery<W> for CRLiteQuery<'_> {
     fn block(&self) -> &[u8] {
-        self.key.issuer.as_ref()
+        &self.key.issuer.0
     }
 
     fn as_query(&self, m: usize) -> Equation<W> {
@@ -103,8 +118,8 @@ impl Queryable<W> for CRLiteQuery<'_> {
         let Some((log_id, timestamp)) = self.log_timestamp else {
             return false;
         };
-        if let Some((low, high)) = universe.0.get(log_id) {
-            if *low <= timestamp && timestamp <= *high {
+        if let Some(interval) = universe.0.get(&log_id) {
+            if interval.low <= timestamp && timestamp <= interval.high {
                 return true;
             }
         }
@@ -178,13 +193,17 @@ impl std::fmt::Display for CRLiteClubcard {
             .universe()
             .0
             .iter()
-            .map(|(log_id, (low, high))| {
-                (base64::prelude::BASE64_STANDARD.encode(log_id), *low, *high)
+            .map(|(log_id, interval)| {
+                (
+                    base64::prelude::BASE64_STANDARD.encode(log_id.0),
+                    interval.low,
+                    interval.high,
+                )
             })
-            .collect::<Vec<(String, u64, u64)>>();
-        coverage_data.sort_by_key(|x| u64::MAX - x.2);
+            .collect::<Vec<_>>();
+        coverage_data.sort_by_key(|x| u64::MAX - x.2 .0);
         for (log_id, low, high) in coverage_data {
-            writeln!(f, "{: >46},{: >16},{: >16}", log_id, low, high)?;
+            writeln!(f, "{: >46},{: >16},{: >16}", log_id, low.0, high.0)?;
         }
         writeln!(f)?;
         writeln!(f, "{:=^80}", " Index ")?;
@@ -262,7 +281,7 @@ impl CRLiteClubcard {
     pub fn contains<'a>(
         &self,
         key: &CRLiteKey<'a>,
-        timestamps: impl Iterator<Item = (&'a LogId, Timestamp)>,
+        timestamps: impl Iterator<Item = (LogId, Timestamp)>,
     ) -> CRLiteStatus {
         for (log_id, timestamp) in timestamps {
             let crlite_query = CRLiteQuery::new(key, Some((log_id, timestamp)));


### PR DESCRIPTION
I think this would be nice to have to create a little more clarity in the API (where the current aliases are not used consistently) -- and especially since `IssuerSpkiHash` and `LogId` reduce to the same `[u8; 32]` type. Ran into this while working on the TLS-like encoding, which I will submit based on feedback on this PR.

cc @ctz