### PR TITLE
Custom TLS-like encoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,14 +9,16 @@ edition = "2021"
 
 [dependencies]
 base64 = "0.21"
-bincode = "1.3"
-clubcard = "0.3"
+bincode = { version = "1.3", optional = true }
+clubcard = "0.3.3"
 rand = { version = "0.8", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1", optional = true }
 sha2 = "0.10"
 
 [features]
+default = ["bincode"]
+bincode = ["dep:bincode"]
 builder = ["dep:rand", "dep:serde_json", "clubcard/builder"]
 
 [dev-dependencies]

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -133,80 +133,13 @@ impl Filterable<4> for CRLiteBuilderItem {
 mod tests {
     use crate::builder::*;
     use clubcard::builder::*;
+    use clubcard::Clubcard;
     use clubcard::Membership;
     use std::collections::HashMap;
 
     #[test]
     fn test_crlite_clubcard() {
-        let subset_sizes = [1 << 17, 1 << 16, 1 << 15, 1 << 14, 1 << 13];
-        let universe_size = 1 << 18;
-
-        let mut clubcard_builder = ClubcardBuilder::new();
-        let mut approx_builders = vec![];
-        for (i, n) in subset_sizes.iter().enumerate() {
-            let mut r = clubcard_builder.new_approx_builder(&[i as u8; 32]);
-            for j in 0usize..*n {
-                r.insert(CRLiteBuilderItem::revoked(
-                    IssuerSpkiHash([i as u8; 32]),
-                    j.to_le_bytes().to_vec(),
-                ));
-            }
-            r.set_universe_size(universe_size);
-            approx_builders.push(r)
-        }
-
-        let approx_ribbons = approx_builders
-            .drain(..)
-            .map(ApproximateRibbon::from)
-            .collect();
-
-        println!("Approx ribbons:");
-        for r in &approx_ribbons {
-            println!("\t{}", r);
-        }
-
-        clubcard_builder.collect_approx_ribbons(approx_ribbons);
-
-        let mut exact_builders = vec![];
-        for (i, n) in subset_sizes.iter().enumerate() {
-            let mut r = clubcard_builder.new_exact_builder(&[i as u8; 32]);
-            for j in 0usize..universe_size {
-                r.insert(if j < *n {
-                    CRLiteBuilderItem::revoked(
-                        IssuerSpkiHash([i as u8; 32]),
-                        j.to_le_bytes().to_vec(),
-                    )
-                } else {
-                    CRLiteBuilderItem::not_revoked(
-                        IssuerSpkiHash([i as u8; 32]),
-                        j.to_le_bytes().to_vec(),
-                    )
-                });
-            }
-            exact_builders.push(r)
-        }
-
-        let exact_ribbons = exact_builders.drain(..).map(ExactRibbon::from).collect();
-
-        println!("Exact ribbons:");
-        for r in &exact_ribbons {
-            println!("\t{}", r);
-        }
-
-        clubcard_builder.collect_exact_ribbons(exact_ribbons);
-
-        let mut log_coverage = HashMap::new();
-        log_coverage.insert(
-            LogId([0u8; 32]),
-            TimestampInterval {
-                low: Timestamp(0),
-                high: Timestamp(u64::MAX),
-            },
-        );
-
-        let clubcard = clubcard_builder.build::<CRLiteQuery>(CRLiteCoverage(log_coverage), ());
-        println!("{}", clubcard);
-
+        let (subset_sizes, universe_size, clubcard) = build_clubcard();
         let sum_subset_sizes: usize = subset_sizes.iter().sum();
         let sum_universe_sizes: usize = subset_sizes.len() * universe_size;
         let min_size = (sum_subset_sizes as f64)
@@ -278,5 +211,77 @@ mod tests {
             clubcard.contains(&query),
             Membership::NotInUniverse
         ));
+    }
+
+    fn build_clubcard() -> ([usize; 5], usize, Clubcard<4, CRLiteCoverage, ()>) {
+        let subset_sizes = [1 << 17, 1 << 16, 1 << 15, 1 << 14, 1 << 13];
+        let universe_size = 1 << 18;
+
+        let mut clubcard_builder = ClubcardBuilder::new();
+        let mut approx_builders = vec![];
+        for (i, n) in subset_sizes.iter().enumerate() {
+            let mut r = clubcard_builder.new_approx_builder(&[i as u8; 32]);
+            for j in 0usize..*n {
+                r.insert(CRLiteBuilderItem::revoked(
+                    IssuerSpkiHash([i as u8; 32]),
+                    j.to_le_bytes().to_vec(),
+                ));
+            }
+            r.set_universe_size(universe_size);
+            approx_builders.push(r)
+        }
+
+        let approx_ribbons = approx_builders
+            .drain(..)
+            .map(ApproximateRibbon::from)
+            .collect();
+
+        println!("Approx ribbons:");
+        for r in &approx_ribbons {
+            println!("\t{}", r);
+        }
+
+        clubcard_builder.collect_approx_ribbons(approx_ribbons);
+
+        let mut exact_builders = vec![];
+        for (i, n) in subset_sizes.iter().enumerate() {
+            let mut r = clubcard_builder.new_exact_builder(&[i as u8; 32]);
+            for j in 0usize..universe_size {
+                r.insert(if j < *n {
+                    CRLiteBuilderItem::revoked(
+                        IssuerSpkiHash([i as u8; 32]),
+                        j.to_le_bytes().to_vec(),
+                    )
+                } else {
+                    CRLiteBuilderItem::not_revoked(
+                        IssuerSpkiHash([i as u8; 32]),
+                        j.to_le_bytes().to_vec(),
+                    )
+                });
+            }
+            exact_builders.push(r)
+        }
+
+        let exact_ribbons = exact_builders.drain(..).map(ExactRibbon::from).collect();
+
+        println!("Exact ribbons:");
+        for r in &exact_ribbons {
+            println!("\t{}", r);
+        }
+
+        clubcard_builder.collect_exact_ribbons(exact_ribbons);
+
+        let mut log_coverage = HashMap::new();
+        log_coverage.insert(
+            LogId([0u8; 32]),
+            TimestampInterval {
+                low: Timestamp(0),
+                high: Timestamp(u64::MAX),
+            },
+        );
+
+        let clubcard = clubcard_builder.build::<CRLiteQuery>(CRLiteCoverage(log_coverage), ());
+        println!("{}", clubcard);
+        (subset_sizes, universe_size, clubcard)
     }
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -131,11 +131,16 @@ impl Filterable<4> for CRLiteBuilderItem {
 
 #[cfg(test)]
 mod tests {
-    use crate::builder::*;
+    use std::collections::HashMap;
+
     use clubcard::builder::*;
     use clubcard::Clubcard;
     use clubcard::Membership;
-    use std::collections::HashMap;
+
+    use crate::builder::*;
+    use crate::codec::Codec;
+    use crate::query::Encoding;
+    use crate::CRLiteClubcard;
 
     #[test]
     fn test_crlite_clubcard() {
@@ -211,6 +216,35 @@ mod tests {
             clubcard.contains(&query),
             Membership::NotInUniverse
         ));
+    }
+
+    #[test]
+    fn test_serialization_roundtrip() {
+        let (subset_sizes, universe_size, clubcard) = build_clubcard();
+
+        let crlite = CRLiteClubcard::from(clubcard);
+        for encoding in [Encoding::V3, Encoding::V4] {
+            let bytes = crlite.to_bytes(encoding).unwrap();
+
+            // Version prefix is LE u16 0x0004
+            assert_eq!(Encoding::read(&bytes).unwrap().0, encoding);
+
+            let restored = CRLiteClubcard::from_bytes(&bytes).unwrap();
+
+            // Verify query results match on all items
+            for i in 0..subset_sizes.len() {
+                let issuer = IssuerSpkiHash([i as u8; 32]);
+                for j in 0..universe_size {
+                    let serial = j.to_le_bytes();
+                    let key = CRLiteKey::new(&issuer, &serial);
+                    let query = CRLiteQuery::new(&key, None);
+                    assert_eq!(
+                        crlite.as_ref().unchecked_contains(&query),
+                        restored.as_ref().unchecked_contains(&query),
+                    );
+                }
+            }
+        }
     }
 
     fn build_clubcard() -> ([usize; 5], usize, Clubcard<4, CRLiteCoverage, ()>) {

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1,0 +1,219 @@
+use clubcard::{Clubcard, ClubcardIndex, ClubcardIndexEntry};
+
+use crate::query::{CRLiteCoverage, ClubcardError};
+use crate::W;
+
+/// A type with a TLS-like binary encoding.
+pub(crate) trait Codec: Sized {
+    /// Append the encoded form of `self` to `buf`.
+    fn encode(&self, buf: &mut Vec<u8>);
+
+    /// Parse one value of `Self` from the front of `buf`.
+    ///
+    /// Returns the parsed value together with the unconsumed remainder of `buf`.
+    fn read(buf: &[u8]) -> Result<(Self, &[u8]), ClubcardError>;
+}
+
+// ```
+// struct {
+//     CRLiteCoverage universe;
+//     ClubcardIndex  index;
+//     FilterColumn   approx_filter<count>;   // uint32 count, then `count` columns
+//     FilterColumn   exact_filter;
+// } Clubcard;
+// ```
+//
+// where `FilterColumn` is `uint64 words<count>` (a uint32 count followed by
+// that many big-endian words).
+impl Codec for Clubcard<W, CRLiteCoverage, ()> {
+    fn encode(&self, buf: &mut Vec<u8>) {
+        self.universe.encode(buf);
+        self.index.encode(buf);
+
+        encode_len::<1>(self.approx_filter.len(), buf);
+        for column in &self.approx_filter {
+            encode_seq::<4, u64>(column, buf);
+        }
+
+        encode_seq::<4, u64>(&self.exact_filter, buf);
+    }
+
+    fn read(buf: &[u8]) -> Result<(Self, &[u8]), ClubcardError> {
+        let (universe, buf) = CRLiteCoverage::read(buf)?;
+        let (index, buf) = ClubcardIndex::read(buf)?;
+        let (column_count, mut buf) = read_len::<1>(buf)?;
+
+        let mut approx_filter = Vec::with_capacity(column_count);
+        for _ in 0..column_count {
+            let (column, rest) = read_seq::<4, u64>(buf)?;
+            approx_filter.push(column);
+            buf = rest;
+        }
+
+        let (exact_filter, buf) = read_seq::<4, u64>(buf)?;
+
+        Ok((
+            Clubcard {
+                universe,
+                partition: (),
+                index,
+                approx_filter,
+                exact_filter,
+            },
+            buf,
+        ))
+    }
+}
+
+// ```
+// struct {
+//     uint8  len;
+//     opaque serial[len];
+// } Exception;                        // serial as opaque<0..2^8-1>
+//
+// struct {
+//     uint32    approx_filter_m;
+//     uint8     approx_filter_rank;
+//     uint32    approx_filter_offset;
+//     uint32    exact_filter_m;
+//     uint32    exact_filter_offset;
+//     uint8     inverted;
+//     Exception exceptions<count>;     // uint16 count, then `count` serials
+// } ClubcardIndexEntry;
+// ```
+impl Codec for ClubcardIndexEntry {
+    fn encode(&self, buf: &mut Vec<u8>) {
+        (self.approx_filter_m as u32).encode(buf);
+        (self.approx_filter_rank as u8).encode(buf);
+        (self.approx_filter_offset as u32).encode(buf);
+        (self.exact_filter_m as u32).encode(buf);
+        (self.exact_filter_offset as u32).encode(buf);
+        (self.inverted as u8).encode(buf);
+
+        encode_len::<2>(self.exceptions.len(), buf);
+        for serial in &self.exceptions {
+            encode_vec::<1>(serial, buf);
+        }
+    }
+
+    fn read(buf: &[u8]) -> Result<(Self, &[u8]), ClubcardError> {
+        let (approx_filter_m, buf) = u32::read(buf)?;
+        let (approx_filter_rank, buf) = u8::read(buf)?;
+        let (approx_filter_offset, buf) = u32::read(buf)?;
+        let (exact_filter_m, buf) = u32::read(buf)?;
+        let (exact_filter_offset, buf) = u32::read(buf)?;
+        let (inverted, buf) = u8::read(buf)?;
+
+        let (count, mut buf) = read_len::<2>(buf)?;
+        let mut exceptions = Vec::with_capacity(count);
+        for _ in 0..count {
+            let (serial, rest) = read_vec::<1>(buf)?;
+            exceptions.push(serial.to_vec());
+            buf = rest;
+        }
+
+        Ok((
+            ClubcardIndexEntry {
+                approx_filter_m: approx_filter_m as usize,
+                exact_filter_m: exact_filter_m as usize,
+                approx_filter_rank: approx_filter_rank as usize,
+                approx_filter_offset: approx_filter_offset as usize,
+                exact_filter_offset: exact_filter_offset as usize,
+                inverted: inverted != 0,
+                exceptions,
+            },
+            buf,
+        ))
+    }
+}
+
+// `uint64`, big-endian.
+impl Codec for u64 {
+    fn encode(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(&self.to_be_bytes());
+    }
+
+    fn read(buf: &[u8]) -> Result<(Self, &[u8]), ClubcardError> {
+        let (bytes, rest) = buf.split_first_chunk().ok_or(ClubcardError::Deserialize)?;
+        Ok((u64::from_be_bytes(*bytes), rest))
+    }
+}
+
+// `uint32`, big-endian.
+impl Codec for u32 {
+    fn encode(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(&self.to_be_bytes());
+    }
+
+    fn read(buf: &[u8]) -> Result<(Self, &[u8]), ClubcardError> {
+        let (bytes, rest) = buf.split_first_chunk().ok_or(ClubcardError::Deserialize)?;
+        Ok((u32::from_be_bytes(*bytes), rest))
+    }
+}
+
+// `uint8`.
+impl Codec for u8 {
+    fn encode(&self, buf: &mut Vec<u8>) {
+        buf.push(*self);
+    }
+
+    fn read(buf: &[u8]) -> Result<(Self, &[u8]), ClubcardError> {
+        let (&val, rest) = buf.split_first().ok_or(ClubcardError::Deserialize)?;
+        Ok((val, rest))
+    }
+}
+
+/// Append an `N`-byte big-endian length (or item count) prefix.
+pub(crate) fn encode_len<const N: usize>(len: usize, buf: &mut Vec<u8>) {
+    buf.extend_from_slice(&len.to_be_bytes()[size_of::<usize>() - N..]);
+}
+
+/// Read an `N`-byte big-endian length (or item count) prefix.
+pub(crate) fn read_len<const N: usize>(buf: &[u8]) -> Result<(usize, &[u8]), ClubcardError> {
+    let (len, rest) = buf
+        .split_first_chunk::<N>()
+        .ok_or(ClubcardError::Deserialize)?;
+
+    let mut padded = [0u8; size_of::<usize>()];
+    padded[size_of::<usize>() - N..].copy_from_slice(len);
+    Ok((usize::from_be_bytes(padded), rest))
+}
+
+/// opaque content<0..2^(8*N)-1>: an `N`-byte byte-length prefix followed by the bytes.
+pub(crate) fn encode_vec<const N: usize>(content: &[u8], buf: &mut Vec<u8>) {
+    encode_len::<N>(content.len(), buf);
+    buf.extend_from_slice(content);
+}
+
+pub(crate) fn read_vec<const N: usize>(buf: &[u8]) -> Result<(&[u8], &[u8]), ClubcardError> {
+    let (len, rest) = read_len::<N>(buf)?;
+    rest.split_at_checked(len).ok_or(ClubcardError::Deserialize)
+}
+
+/// `T items<count>`: an `N`-byte item *count* prefix followed by that many encoded `T`s.
+///
+/// Unlike a byte-length prefix, the explicit count lets [`read_seq`] size the
+/// result vector with a single allocation up front.
+pub(crate) fn encode_seq<const N: usize, T: Codec>(items: &[T], buf: &mut Vec<u8>) {
+    encode_len::<N>(items.len(), buf);
+    for item in items {
+        item.encode(buf);
+    }
+}
+
+pub(crate) fn read_seq<const N: usize, T: Codec>(
+    buf: &[u8],
+) -> Result<(Vec<T>, &[u8]), ClubcardError> {
+    let (count, mut buf) = read_len::<N>(buf)?;
+
+    // Every item is at least one byte, so the remaining length bounds the count.
+    // Capping the reservation keeps a corrupt prefix from forcing a huge allocation.
+    let mut items = Vec::with_capacity(count);
+    for _ in 0..count {
+        let (item, rest) = T::read(buf)?;
+        items.push(item);
+        buf = rest;
+    }
+
+    Ok((items, buf))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,12 @@
 #[cfg(feature = "builder")]
 pub mod builder;
 
+mod codec;
+
 mod query;
 pub use query::{
     CRLiteClubcard, CRLiteCoverage, CRLiteKey, CRLiteQuery, CRLiteStatus, Encoding, IssuerSpkiHash,
     LogId, Timestamp, TimestampInterval,
 };
+
+pub(crate) const W: usize = 4;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,6 @@ pub mod builder;
 
 mod query;
 pub use query::{
-    CRLiteClubcard, CRLiteCoverage, CRLiteKey, CRLiteQuery, CRLiteStatus, IssuerSpkiHash, LogId,
-    Timestamp, TimestampInterval,
+    CRLiteClubcard, CRLiteCoverage, CRLiteKey, CRLiteQuery, CRLiteStatus, Encoding, IssuerSpkiHash,
+    LogId, Timestamp, TimestampInterval,
 };

--- a/src/query.rs
+++ b/src/query.rs
@@ -242,12 +242,9 @@ impl std::fmt::Display for CRLiteClubcard {
 }
 
 impl CRLiteClubcard {
-    // Cascade-based CRLite filters use version numbers 0x0000, 0x0001, and 0x0002.
-    const SERIALIZATION_VERSION: u16 = 0x0003;
-
     /// Serialize this clubcard.
     pub fn to_bytes(&self) -> Result<Vec<u8>, ClubcardError> {
-        let mut out = u16::to_le_bytes(Self::SERIALIZATION_VERSION).to_vec();
+        let mut out = Encoding::V3.to_vec();
         bincode::serialize_into(&mut out, &self.0).map_err(|_| ClubcardError::Serialize)?;
         Ok(out)
     }
@@ -258,7 +255,7 @@ impl CRLiteClubcard {
             return Err(ClubcardError::Deserialize);
         };
 
-        if u16::from_le_bytes(*version_bytes) != Self::SERIALIZATION_VERSION {
+        if Encoding::try_from(version_bytes)? != Encoding::V3 {
             return Err(ClubcardError::UnsupportedVersion);
         }
 
@@ -302,5 +299,29 @@ impl ApproximateSizeOf for CRLiteCoverage {
 impl ApproximateSizeOf for CRLiteClubcard {
     fn approximate_size_of(&self) -> usize {
         self.0.approximate_size_of()
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u16)]
+pub enum Encoding {
+    // Cascade-based CRLite filters use version numbers 0x0000, 0x0001, and 0x0002.
+    V3 = 3,
+}
+
+impl Encoding {
+    fn to_vec(self) -> Vec<u8> {
+        (self as u16).to_le_bytes().to_vec()
+    }
+}
+
+impl TryFrom<&[u8; 2]> for Encoding {
+    type Error = ClubcardError;
+
+    fn try_from(bytes: &[u8; 2]) -> Result<Self, Self::Error> {
+        match u16::from_le_bytes(*bytes) {
+            3 => Ok(Self::V3),
+            _ => Err(ClubcardError::UnsupportedVersion),
+        }
     }
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -3,19 +3,21 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use std::cmp::max;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::error::Error;
 use std::fmt;
 use std::mem::size_of;
 
 use base64::Engine;
 use clubcard::{
-    ApproximateSizeOf, AsQuery, Clubcard, ClubcardIndex, Equation, Membership, Queryable,
+    ApproximateSizeOf, AsQuery, Clubcard, ClubcardIndex, ClubcardIndexEntry, Equation, Membership,
+    Queryable,
 };
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
-const W: usize = 4;
+use crate::codec::{encode_len, read_len, Codec};
+use crate::W;
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct IssuerSpkiHash(pub [u8; 32]);
@@ -23,13 +25,60 @@ pub struct IssuerSpkiHash(pub [u8; 32]);
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct LogId(pub [u8; 32]);
 
+// opaque LogId[32]: a fixed-width 32-byte SHA-256 digest, no length prefix.
+impl Codec for LogId {
+    fn encode(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(&self.0);
+    }
+
+    fn read(buf: &[u8]) -> Result<(Self, &[u8]), ClubcardError> {
+        match buf.split_first_chunk() {
+            Some((bytes, rest)) => Ok((LogId(*bytes), rest)),
+            None => Err(ClubcardError::Deserialize),
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Ord, PartialOrd, PartialEq, Serialize)]
 pub struct Timestamp(pub u64);
+
+impl Timestamp {
+    pub const MIN: Timestamp = Timestamp(0);
+    pub const MAX: Timestamp = Timestamp(u64::MAX);
+}
+
+// uint64 Timestamp, big-endian (see the u64 Codec impl).
+impl Codec for Timestamp {
+    fn encode(&self, buf: &mut Vec<u8>) {
+        self.0.encode(buf);
+    }
+
+    fn read(buf: &[u8]) -> Result<(Self, &[u8]), ClubcardError> {
+        u64::read(buf).map(|(val, rest)| (Timestamp(val), rest))
+    }
+}
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 pub struct TimestampInterval {
     pub low: Timestamp,
     pub high: Timestamp,
+}
+
+// struct {
+//     Timestamp low;
+//     Timestamp high;
+// } TimestampInterval;
+impl Codec for TimestampInterval {
+    fn encode(&self, buf: &mut Vec<u8>) {
+        self.low.encode(buf);
+        self.high.encode(buf);
+    }
+
+    fn read(buf: &[u8]) -> Result<(Self, &[u8]), ClubcardError> {
+        let (low, buf) = Timestamp::read(buf)?;
+        let (high, buf) = Timestamp::read(buf)?;
+        Ok((TimestampInterval { low, high }, buf))
+    }
 }
 
 #[derive(Serialize, Deserialize)]
@@ -38,6 +87,68 @@ pub struct CRLiteCoverage(pub(crate) HashMap<LogId, TimestampInterval>);
 impl CRLiteCoverage {
     pub fn iter(&self) -> impl Iterator<Item = (&LogId, &TimestampInterval)> {
         self.0.iter()
+    }
+}
+
+// struct {
+//     LogId             log_id;
+//     TimestampInterval interval;
+// } Coverage;
+//
+// Coverage coverage<count>;   // uint16 count, then `count` entries
+impl Codec for CRLiteCoverage {
+    fn encode(&self, buf: &mut Vec<u8>) {
+        encode_len::<2>(self.0.len(), buf);
+        for (log_id, interval) in &self.0 {
+            log_id.encode(buf);
+            interval.encode(buf);
+        }
+    }
+
+    fn read(buf: &[u8]) -> Result<(Self, &[u8]), ClubcardError> {
+        let (count, mut buf) = read_len::<2>(buf)?;
+
+        let mut map = HashMap::with_capacity(count);
+        for _ in 0..count {
+            let (log_id, rest) = LogId::read(buf)?;
+            let (interval, rest) = TimestampInterval::read(rest)?;
+            map.insert(log_id, interval);
+            buf = rest;
+        }
+
+        Ok((Self(map), buf))
+    }
+}
+
+// struct {
+//     opaque             block_id[32];
+//     ClubcardIndexEntry entry;
+// } IndexEntry;
+//
+// IndexEntry index<count>;   // uint32 count, then `count` entries
+impl Codec for ClubcardIndex {
+    fn encode(&self, buf: &mut Vec<u8>) {
+        encode_len::<4>(self.len(), buf);
+        for (block_id, entry) in self {
+            buf.extend_from_slice(block_id);
+            entry.encode(buf);
+        }
+    }
+
+    fn read(buf: &[u8]) -> Result<(Self, &[u8]), ClubcardError> {
+        let (count, mut buf) = read_len::<4>(buf)?;
+        let mut index = BTreeMap::new();
+        for _ in 0..count {
+            let Some((block_id, rest)) = buf.split_first_chunk::<32>() else {
+                return Err(ClubcardError::Deserialize);
+            };
+
+            let (entry, rest) = ClubcardIndexEntry::read(rest)?;
+            index.insert(block_id.to_vec(), entry);
+            buf = rest;
+        }
+
+        Ok((index, buf))
     }
 }
 
@@ -243,25 +354,37 @@ impl std::fmt::Display for CRLiteClubcard {
 
 impl CRLiteClubcard {
     /// Serialize this clubcard.
-    pub fn to_bytes(&self) -> Result<Vec<u8>, ClubcardError> {
-        let mut out = Encoding::V3.to_vec();
-        bincode::serialize_into(&mut out, &self.0).map_err(|_| ClubcardError::Serialize)?;
+    pub fn to_bytes(&self, encoding: Encoding) -> Result<Vec<u8>, ClubcardError> {
+        let mut out = Vec::with_capacity(2 + self.0.approximate_size_of());
+        encoding.encode(&mut out);
+
+        match encoding {
+            #[cfg(feature = "bincode")]
+            Encoding::V3 => {
+                bincode::serialize_into(&mut out, &self.0).map_err(|_| ClubcardError::Serialize)?
+            }
+            Encoding::V4 => self.0.encode(&mut out),
+        }
+
         Ok(out)
     }
 
     /// Deserialize a clubcard.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, ClubcardError> {
-        let Some((version_bytes, rest)) = bytes.split_first_chunk() else {
-            return Err(ClubcardError::Deserialize);
-        };
-
-        if Encoding::try_from(version_bytes)? != Encoding::V3 {
-            return Err(ClubcardError::UnsupportedVersion);
+        match Encoding::read(bytes)? {
+            #[cfg(feature = "bincode")]
+            (Encoding::V3, rest) => match bincode::deserialize(rest) {
+                Ok(clubcard) => Ok(Self(clubcard)),
+                Err(_) => Err(ClubcardError::Deserialize),
+            },
+            (Encoding::V4, rest) => {
+                let (clubcard, rest) = Clubcard::read(rest)?;
+                if !rest.is_empty() {
+                    return Err(ClubcardError::Deserialize);
+                }
+                Ok(Self(clubcard))
+            }
         }
-
-        bincode::deserialize(rest)
-            .map(CRLiteClubcard)
-            .map_err(|_| ClubcardError::Deserialize)
     }
 
     pub fn universe(&self) -> &CRLiteCoverage {
@@ -306,21 +429,25 @@ impl ApproximateSizeOf for CRLiteClubcard {
 #[repr(u16)]
 pub enum Encoding {
     // Cascade-based CRLite filters use version numbers 0x0000, 0x0001, and 0x0002.
+    #[cfg(feature = "bincode")]
     V3 = 3,
+    V4 = 4,
 }
 
-impl Encoding {
-    fn to_vec(self) -> Vec<u8> {
-        (self as u16).to_le_bytes().to_vec()
+impl Codec for Encoding {
+    fn encode(&self, buf: &mut Vec<u8>) {
+        buf.extend((*self as u16).to_le_bytes());
     }
-}
 
-impl TryFrom<&[u8; 2]> for Encoding {
-    type Error = ClubcardError;
+    fn read(buf: &[u8]) -> Result<(Self, &[u8]), ClubcardError> {
+        let Some((value, rest)) = buf.split_first_chunk::<2>() else {
+            return Err(ClubcardError::Deserialize);
+        };
 
-    fn try_from(bytes: &[u8; 2]) -> Result<Self, Self::Error> {
-        match u16::from_le_bytes(*bytes) {
-            3 => Ok(Self::V3),
+        match u16::from_le_bytes(*value) {
+            #[cfg(feature = "bincode")]
+            3 => Ok((Encoding::V3, rest)),
+            4 => Ok((Encoding::V4, rest)),
             _ => Err(ClubcardError::UnsupportedVersion),
         }
     }

--- a/src/query.rs
+++ b/src/query.rs
@@ -254,17 +254,14 @@ impl CRLiteClubcard {
 
     /// Deserialize a clubcard.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, ClubcardError> {
-        if bytes.len() < size_of::<u16>() {
-            return Err(ClubcardError::Deserialize);
-        }
-        let (version_bytes, rest) = bytes.split_at(size_of::<u16>());
-        let Ok(version_bytes) = version_bytes.try_into() else {
+        let Some((version_bytes, rest)) = bytes.split_first_chunk() else {
             return Err(ClubcardError::Deserialize);
         };
-        let version = u16::from_le_bytes(version_bytes);
-        if version != Self::SERIALIZATION_VERSION {
+
+        if u16::from_le_bytes(*version_bytes) != Self::SERIALIZATION_VERSION {
             return Err(ClubcardError::UnsupportedVersion);
         }
+
         bincode::deserialize(rest)
             .map(CRLiteClubcard)
             .map_err(|_| ClubcardError::Deserialize)

--- a/src/query.rs
+++ b/src/query.rs
@@ -20,7 +20,7 @@ const W: usize = 4;
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct IssuerSpkiHash(pub [u8; 32]);
 
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct LogId(pub [u8; 32]);
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Ord, PartialOrd, PartialEq, Serialize)]


### PR DESCRIPTION
Based on previous discussions, this replaces the bincode-based serialization with a custom binary encoding format based on the TLS presentation language. It bumps the `SERIALIZATION_VERSION` to 4.

I have not yet tested the size/performance benefits on real-world data. If there's an easy way for me to get a sample data set, I'm happy to do that next.

Also happy to discuss further tweaks/optimizations.

r? @ctz

Fixes #18; alternative to #19.