### PR TITLE
Make sha2 dependency optional for querying

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,6 +45,7 @@ jobs:
           version: ${{ matrix.rust }}
       - run: cargo test --all-features
       - run: cargo test --no-default-features
+      - run: cargo check --all-targets --no-default-features --features builder
 
   lint:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,17 @@ bincode = { version = "1.3", optional = true }
 clubcard = "0.3.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1", optional = true }
-sha2 = "0.10"
+sha2 = { version = "0.10", optional = true }
 
 [features]
-default = ["bincode"]
+default = ["bincode", "sha2"]
 bincode = ["dep:bincode"]
-builder = ["dep:serde_json", "clubcard/builder"]
+builder = ["dep:serde_json", "sha2", "clubcard/builder"]
+sha2 = ["dep:sha2"]
 
 [dev-dependencies]
 x509-parser = { version = "0.16", features = ["verify"] }
+
+[[example]]
+name = "query"
+required-features = ["sha2"]

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -138,8 +138,11 @@ mod tests {
     use clubcard::Membership;
 
     use crate::builder::*;
+    #[cfg(feature = "bincode")]
     use crate::codec::Codec;
+    #[cfg(feature = "bincode")]
     use crate::query::Encoding;
+    #[cfg(feature = "bincode")]
     use crate::CRLiteClubcard;
 
     #[test]
@@ -218,6 +221,7 @@ mod tests {
         ));
     }
 
+    #[cfg(feature = "bincode")]
     #[test]
     fn test_serialization_roundtrip() {
         let (subset_sizes, universe_size, clubcard) = build_clubcard();

--- a/src/query.rs
+++ b/src/query.rs
@@ -14,6 +14,7 @@ use clubcard::{
     Queryable,
 };
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "sha2")]
 use sha2::{Digest, Sha256};
 
 use crate::codec::{encode_len, read_len, Codec};
@@ -160,6 +161,7 @@ pub struct CRLiteKey<'a> {
 }
 
 impl<'a> CRLiteKey<'a> {
+    #[cfg(feature = "sha2")]
     pub fn new(issuer: &'a IssuerSpkiHash, serial: &'a [u8]) -> CRLiteKey<'a> {
         let mut hasher = Sha256::new();
         hasher.update(issuer.0);
@@ -167,6 +169,22 @@ impl<'a> CRLiteKey<'a> {
 
         let mut issuer_serial_hash = [0u8; 32];
         hasher.finalize_into((&mut issuer_serial_hash).into());
+        CRLiteKey {
+            issuer,
+            serial,
+            issuer_serial_hash,
+        }
+    }
+
+    /// Create a CRLiteKey with a precomputed issuer_serial_hash.
+    ///
+    /// The `issuer_serial_hash` must be the `SHA256(issuer || serial)`. This is not verified
+    /// by this function; it is the caller's responsibility to ensure that the provided hash is correct.
+    pub fn with_hash(
+        issuer: &'a IssuerSpkiHash,
+        serial: &'a [u8],
+        issuer_serial_hash: [u8; 32],
+    ) -> CRLiteKey<'a> {
         CRLiteKey {
             issuer,
             serial,


### PR DESCRIPTION
When used with rustls, we'd prefer to use the TLS crypto provider instead of pulling an extra dependency.

Alternatively, we could define a trait for SHA256 hashing.