### PR TITLE
codec: fix Clubcard approx_fiter count datatype

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -18,7 +18,7 @@ pub(crate) trait Codec: Sized {
 // struct {
 //     CRLiteCoverage universe;
 //     ClubcardIndex  index;
-//     FilterColumn   approx_filter<count>;   // uint32 count, then `count` columns
+//     FilterColumn   approx_filter<count>;   // uint8 count, then `count` columns
 //     FilterColumn   exact_filter;
 // } Clubcard;
 // ```


### PR DESCRIPTION
The TLS presentation language comment described the `Clubcard` struct's `approx_filter<count>` field's count as being a `uint32`:

https://github.com/mozilla/clubcard-crlite/blob/a626df649b9f3cfd68e8c3a268f06fb955f9f706/src/codec.rs#L21

But when it was encoded, it was written as `encode_len::<1>(...)`, writing a `uint8`:

https://github.com/mozilla/clubcard-crlite/blob/a626df649b9f3cfd68e8c3a268f06fb955f9f706/src/codec.rs#L33

I think given the context the code was correct, and the comment was incorrect so I've updated accordingly, but I'd appreciate a spot-check.