### PR TITLE
Downgrade MSRV to 1.85

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "clubcard-crlite"
 authors = ["John M. Schanck <jschanck@mozilla.com>"]
-version = "0.5.0"
+version = "0.5.1"
 license = "MPL-2.0"
 repository = "https://github.com/mozilla/clubcard-crlite/"
 description = "An instantiation of Clubcard for use in CRLite"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/mozilla/clubcard-crlite/"
 description = "An instantiation of Clubcard for use in CRLite"
 edition = "2021"
 # Keep at or below Firefox's Rust requirement (currently 1.90).
-rust-version = "1.90"
+rust-version = "1.85"
 
 [dependencies]
 base64 = "0.22"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.5.0"
 license = "MPL-2.0"
 repository = "https://github.com/mozilla/clubcard-crlite/"
 description = "An instantiation of Clubcard for use in CRLite"
-edition = "2021"
+edition = "2024"
 # Keep at or below Firefox's Rust requirement (currently 1.90).
 rust-version = "1.85"
 

--- a/deny.toml
+++ b/deny.toml
@@ -8,6 +8,8 @@ yanked = "deny"
 ignore = [
     # bincode 1.x is intentionally unmaintained; kept for legacy compatibility.
     "RUSTSEC-2025-0141",
+    # time is used as a dev-dependency only so far, fixed versions have a higher MSRV
+    "RUSTSEC-2026-0009",
 ]
 
 [licenses]

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -133,17 +133,17 @@ impl Filterable<4> for CRLiteBuilderItem {
 mod tests {
     use std::collections::HashMap;
 
-    use clubcard::builder::*;
     use clubcard::Clubcard;
     use clubcard::Membership;
+    use clubcard::builder::*;
 
+    #[cfg(feature = "bincode")]
+    use crate::CRLiteClubcard;
     use crate::builder::*;
     #[cfg(feature = "bincode")]
     use crate::codec::Codec;
     #[cfg(feature = "bincode")]
     use crate::query::Encoding;
-    #[cfg(feature = "bincode")]
-    use crate::CRLiteClubcard;
 
     #[test]
     fn test_crlite_clubcard() {

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1,7 +1,7 @@
 use clubcard::{Clubcard, ClubcardIndex, ClubcardIndexEntry};
 
-use crate::query::{CRLiteCoverage, ClubcardError};
 use crate::W;
+use crate::query::{CRLiteCoverage, ClubcardError};
 
 /// A type with a TLS-like binary encoding.
 pub(crate) trait Codec: Sized {

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -223,9 +223,11 @@ pub(crate) fn read_u64_seq(buf: &[u8]) -> Result<(Vec<u64>, &[u8]), ClubcardErro
             "not enough bytes for u64 sequence data".into(),
         ))?;
 
-    let (chunks, _) = words.as_chunks::<{ size_of::<u64>() }>();
     let mut items = Vec::with_capacity(count);
-    items.extend(chunks.iter().map(|&chunk| u64::from_be_bytes(chunk)));
+    // Use `as_chunks()` when MSRV is 1.88 or later
+    items.extend(words.chunks_exact(size_of::<u64>()).map(|chunk| {
+        u64::from_be_bytes(<[u8; size_of::<u64>()]>::try_from(chunk).expect("chunk is u64-sized"))
+    }));
 
     Ok((items, rest))
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -17,8 +17,8 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "sha2")]
 use sha2::{Digest, Sha256};
 
-use crate::codec::{encode_len, read_len, Codec};
 use crate::W;
+use crate::codec::{Codec, encode_len, read_len};
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct IssuerSpkiHash(pub [u8; 32]);
@@ -343,7 +343,7 @@ impl std::fmt::Display for CRLiteClubcard {
                 )
             })
             .collect::<Vec<_>>();
-        coverage_data.sort_by_key(|x| u64::MAX - x.2 .0);
+        coverage_data.sort_by_key(|x| u64::MAX - x.2.0);
         for (log_id, low, high) in coverage_data {
             writeln!(f, "{: >46},{: >16},{: >16}", log_id, low.0, high.0)?;
         }


### PR DESCRIPTION
We'd like to use a more conservative MSRV for downstream libraries.