### PR TITLE
Change encoding version repr to u8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "clubcard-crlite"
 authors = ["John M. Schanck <jschanck@mozilla.com>"]
-version = "0.5.1"
+version = "0.6.0"
 license = "MPL-2.0"
 repository = "https://github.com/mozilla/clubcard-crlite/"
 description = "An instantiation of Clubcard for use in CRLite"

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -230,7 +230,7 @@ mod tests {
         for encoding in [Encoding::V3, Encoding::V4] {
             let bytes = crlite.to_bytes(encoding).unwrap();
 
-            // Version prefix is LE u16 0x0004
+            // Version prefix is a u8 version followed by a zero reserved0 byte
             assert_eq!(Encoding::read(&bytes).unwrap().0, encoding);
 
             let restored = CRLiteClubcard::from_bytes(&bytes).unwrap();

--- a/src/query.rs
+++ b/src/query.rs
@@ -264,7 +264,7 @@ impl Queryable<W> for CRLiteQuery<'_> {
 pub enum ClubcardError {
     Serialize(Box<dyn Error + Send + Sync>),
     Deserialize(Box<dyn Error + Send + Sync>),
-    UnsupportedVersion(u16),
+    UnsupportedVersion(u8),
 }
 
 impl fmt::Display for ClubcardError {
@@ -458,9 +458,9 @@ impl ApproximateSizeOf for CRLiteClubcard {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[repr(u16)]
+#[repr(u8)]
 pub enum Encoding {
-    // Cascade-based CRLite filters use version numbers 0x0000, 0x0001, and 0x0002.
+    // Cascade-based CRLite filters use version numbers 0x00, 0x01, and 0x02.
     #[cfg(feature = "bincode")]
     V3 = 3,
     V4 = 4,
@@ -468,21 +468,28 @@ pub enum Encoding {
 
 impl Codec for Encoding {
     fn encode(&self, buf: &mut Vec<u8>) {
-        buf.extend((*self as u16).to_le_bytes());
+        buf.push(*self as u8);
+        buf.push(0); // reserved0
     }
 
     fn read(buf: &[u8]) -> Result<(Self, &[u8]), ClubcardError> {
-        let Some((value, rest)) = buf.split_first_chunk::<2>() else {
+        let Some(([version, reserved0], rest)) = buf.split_first_chunk::<2>() else {
             return Err(ClubcardError::Deserialize(
                 "not enough bytes for Encoding".into(),
             ));
         };
 
-        match u16::from_le_bytes(*value) {
+        if *reserved0 != 0 {
+            return Err(ClubcardError::Deserialize(
+                "non-zero reserved0 byte after version".into(),
+            ));
+        }
+
+        match version {
             #[cfg(feature = "bincode")]
             3 => Ok((Encoding::V3, rest)),
             4 => Ok((Encoding::V4, rest)),
-            version => Err(ClubcardError::UnsupportedVersion(version)),
+            version => Err(ClubcardError::UnsupportedVersion(*version)),
         }
     }
 }


### PR DESCRIPTION
Rather than encoding the version as a u16 in little-endian, we'd prefer to encode it as a u8, and an accompanying reserved u8 that's to be zero. In the future we may use the reserved u8 to indicate partition metadata. This better matches the endianness used throughout other aspects of the serialization + related upki revocation specs. See the [C2SP upki-revocation spec discussion here](https://github.com/C2SP/C2SP/pull/278#discussion_r3589579810) for more detail.

This change is wire-compatible with existing serializations, but is a semver breaking API change due to the `#[repr(u8)]` -> `#[repr(u16)]` adjustment of the public `Encoding` enum (Per cargo semver docs, ["Major: Changing the primitive representation of a repr(<int>) enum"](https://doc.rust-lang.org/cargo/reference/semver.html#repr-int-enum-change)), and a similar change to the `ClubcardError::UnsupportedVersion` value.