### PR TITLE
Make Codec::encode() fallible for lengths that are too long

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "clubcard-crlite"
 authors = ["John M. Schanck <jschanck@mozilla.com>"]
-version = "0.6.0"
+version = "0.6.1"
 license = "MPL-2.0"
 repository = "https://github.com/mozilla/clubcard-crlite/"
 description = "An instantiation of Clubcard for use in CRLite"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-base64 = "0.22"
+base64 = "0.23"
 bincode = { version = "1.3", optional = true }
 clubcard = "0.3.3"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -131,6 +131,8 @@ impl Filterable<4> for CRLiteBuilderItem {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::cast_possible_truncation)]
+
     use std::collections::HashMap;
 
     use clubcard::Clubcard;

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -85,15 +85,33 @@ impl Codec for Clubcard<W, CRLiteCoverage, ()> {
 // ```
 impl Codec for ClubcardIndexEntry {
     fn encode(&self, buf: &mut Vec<u8>) -> Result<(), ClubcardError> {
-        (self.approx_filter_m as u32).encode(buf)?;
-        (self.approx_filter_rank as u8).encode(buf)?;
-        (self.approx_filter_offset as u32).encode(buf)?;
-        (self.exact_filter_m as u32).encode(buf)?;
-        (self.exact_filter_offset as u32).encode(buf)?;
-        (self.inverted as u8).encode(buf)?;
+        let Self {
+            approx_filter_m,
+            approx_filter_rank,
+            approx_filter_offset,
+            exact_filter_m,
+            exact_filter_offset,
+            inverted,
+            exceptions,
+        } = self;
 
-        encode_len::<2>(self.exceptions.len(), buf)?;
-        for serial in &self.exceptions {
+        encode_usize_as_u32(*approx_filter_m, "approx_filter_m", buf)?;
+        match u8::try_from(*approx_filter_rank) {
+            Ok(rank) => rank.encode(buf)?,
+            Err(_) => {
+                return Err(ClubcardError::Serialize(
+                    format!("approx_filter_rank value {approx_filter_rank} does not fit in u8")
+                        .into(),
+                ));
+            }
+        }
+        encode_usize_as_u32(*approx_filter_offset, "approx_filter_offset", buf)?;
+        encode_usize_as_u32(*exact_filter_m, "exact_filter_m", buf)?;
+        encode_usize_as_u32(*exact_filter_offset, "exact_filter_offset", buf)?;
+
+        u8::from(*inverted).encode(buf)?;
+        encode_len::<2>(exceptions.len(), buf)?;
+        for serial in exceptions {
             encode_vec::<1>(serial, buf)?;
         }
 
@@ -262,6 +280,18 @@ pub(crate) fn read_u64_seq(buf: &[u8]) -> Result<(Vec<u64>, &[u8]), ClubcardErro
     }));
 
     Ok((items, rest))
+}
+
+/// Encode `number` as a big-endian `uint32`.
+///
+/// Fails if `number` does not fit in a `u32`, naming `name` in the error.
+fn encode_usize_as_u32(number: usize, name: &str, buf: &mut Vec<u8>) -> Result<(), ClubcardError> {
+    match u32::try_from(number) {
+        Ok(number) => number.encode(buf),
+        Err(_) => Err(ClubcardError::Serialize(
+            format!("{name} value {number} does not fit in u32").into(),
+        )),
+    }
 }
 
 #[cfg(test)]

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -6,7 +6,9 @@ use crate::query::{CRLiteCoverage, ClubcardError};
 /// A type with a TLS-like binary encoding.
 pub(crate) trait Codec: Sized {
     /// Append the encoded form of `self` to `buf`.
-    fn encode(&self, buf: &mut Vec<u8>);
+    ///
+    /// Fails if a length or item count does not fit in its length prefix.
+    fn encode(&self, buf: &mut Vec<u8>) -> Result<(), ClubcardError>;
 
     /// Parse one value of `Self` from the front of `buf`.
     ///
@@ -26,16 +28,16 @@ pub(crate) trait Codec: Sized {
 // where `FilterColumn` is `uint64 words<count>` (a uint32 count followed by
 // that many big-endian words).
 impl Codec for Clubcard<W, CRLiteCoverage, ()> {
-    fn encode(&self, buf: &mut Vec<u8>) {
-        self.universe.encode(buf);
-        self.index.encode(buf);
+    fn encode(&self, buf: &mut Vec<u8>) -> Result<(), ClubcardError> {
+        self.universe.encode(buf)?;
+        self.index.encode(buf)?;
 
-        encode_len::<1>(self.approx_filter.len(), buf);
+        encode_len::<1>(self.approx_filter.len(), buf)?;
         for column in &self.approx_filter {
-            encode_seq::<4, u64>(column, buf);
+            encode_seq::<4, u64>(column, buf)?;
         }
 
-        encode_seq::<4, u64>(&self.exact_filter, buf);
+        encode_seq::<4, u64>(&self.exact_filter, buf)
     }
 
     fn read(buf: &[u8]) -> Result<(Self, &[u8]), ClubcardError> {
@@ -82,18 +84,20 @@ impl Codec for Clubcard<W, CRLiteCoverage, ()> {
 // } ClubcardIndexEntry;
 // ```
 impl Codec for ClubcardIndexEntry {
-    fn encode(&self, buf: &mut Vec<u8>) {
-        (self.approx_filter_m as u32).encode(buf);
-        (self.approx_filter_rank as u8).encode(buf);
-        (self.approx_filter_offset as u32).encode(buf);
-        (self.exact_filter_m as u32).encode(buf);
-        (self.exact_filter_offset as u32).encode(buf);
-        (self.inverted as u8).encode(buf);
+    fn encode(&self, buf: &mut Vec<u8>) -> Result<(), ClubcardError> {
+        (self.approx_filter_m as u32).encode(buf)?;
+        (self.approx_filter_rank as u8).encode(buf)?;
+        (self.approx_filter_offset as u32).encode(buf)?;
+        (self.exact_filter_m as u32).encode(buf)?;
+        (self.exact_filter_offset as u32).encode(buf)?;
+        (self.inverted as u8).encode(buf)?;
 
-        encode_len::<2>(self.exceptions.len(), buf);
+        encode_len::<2>(self.exceptions.len(), buf)?;
         for serial in &self.exceptions {
-            encode_vec::<1>(serial, buf);
+            encode_vec::<1>(serial, buf)?;
         }
+
+        Ok(())
     }
 
     fn read(buf: &[u8]) -> Result<(Self, &[u8]), ClubcardError> {
@@ -129,8 +133,9 @@ impl Codec for ClubcardIndexEntry {
 
 // `uint64`, big-endian.
 impl Codec for u64 {
-    fn encode(&self, buf: &mut Vec<u8>) {
+    fn encode(&self, buf: &mut Vec<u8>) -> Result<(), ClubcardError> {
         buf.extend_from_slice(&self.to_be_bytes());
+        Ok(())
     }
 
     fn read(buf: &[u8]) -> Result<(Self, &[u8]), ClubcardError> {
@@ -143,8 +148,9 @@ impl Codec for u64 {
 
 // `uint32`, big-endian.
 impl Codec for u32 {
-    fn encode(&self, buf: &mut Vec<u8>) {
+    fn encode(&self, buf: &mut Vec<u8>) -> Result<(), ClubcardError> {
         buf.extend_from_slice(&self.to_be_bytes());
+        Ok(())
     }
 
     fn read(buf: &[u8]) -> Result<(Self, &[u8]), ClubcardError> {
@@ -157,8 +163,9 @@ impl Codec for u32 {
 
 // `uint8`.
 impl Codec for u8 {
-    fn encode(&self, buf: &mut Vec<u8>) {
+    fn encode(&self, buf: &mut Vec<u8>) -> Result<(), ClubcardError> {
         buf.push(*self);
+        Ok(())
     }
 
     fn read(buf: &[u8]) -> Result<(Self, &[u8]), ClubcardError> {
@@ -170,8 +177,24 @@ impl Codec for u8 {
 }
 
 /// Append an `N`-byte big-endian length (or item count) prefix.
-pub(crate) fn encode_len<const N: usize>(len: usize, buf: &mut Vec<u8>) {
-    buf.extend_from_slice(&len.to_be_bytes()[size_of::<usize>() - N..]);
+///
+/// Fails if `len` does not fit in `N` bytes.
+pub(crate) fn encode_len<const N: usize>(
+    len: usize,
+    buf: &mut Vec<u8>,
+) -> Result<(), ClubcardError> {
+    let bytes = len.to_be_bytes();
+    let (overflow, prefix) = bytes.split_at(size_of::<usize>() - N);
+    for &byte in overflow {
+        if byte != 0 {
+            return Err(ClubcardError::Serialize(
+                format!("length {len} does not fit in a {N}-byte prefix").into(),
+            ));
+        }
+    }
+
+    buf.extend_from_slice(prefix);
+    Ok(())
 }
 
 /// Read an `N`-byte big-endian length (or item count) prefix.
@@ -188,9 +211,13 @@ pub(crate) fn read_len<const N: usize>(buf: &[u8]) -> Result<(usize, &[u8]), Clu
 }
 
 /// opaque content<0..2^(8*N)-1>: an `N`-byte byte-length prefix followed by the bytes.
-pub(crate) fn encode_vec<const N: usize>(content: &[u8], buf: &mut Vec<u8>) {
-    encode_len::<N>(content.len(), buf);
+pub(crate) fn encode_vec<const N: usize>(
+    content: &[u8],
+    buf: &mut Vec<u8>,
+) -> Result<(), ClubcardError> {
+    encode_len::<N>(content.len(), buf)?;
     buf.extend_from_slice(content);
+    Ok(())
 }
 
 pub(crate) fn read_vec<const N: usize>(buf: &[u8]) -> Result<(&[u8], &[u8]), ClubcardError> {
@@ -201,11 +228,16 @@ pub(crate) fn read_vec<const N: usize>(buf: &[u8]) -> Result<(&[u8], &[u8]), Clu
 }
 
 /// `T items<count>`: an `N`-byte item *count* prefix followed by that many encoded `T`s.
-pub(crate) fn encode_seq<const N: usize, T: Codec>(items: &[T], buf: &mut Vec<u8>) {
-    encode_len::<N>(items.len(), buf);
+pub(crate) fn encode_seq<const N: usize, T: Codec>(
+    items: &[T],
+    buf: &mut Vec<u8>,
+) -> Result<(), ClubcardError> {
+    encode_len::<N>(items.len(), buf)?;
     for item in items {
-        item.encode(buf);
+        item.encode(buf)?;
     }
+
+    Ok(())
 }
 
 /// Read `u64 items<count>` sequence; a `u32` item *count* prefix followed by that many `u64`s.
@@ -230,4 +262,56 @@ pub(crate) fn read_u64_seq(buf: &[u8]) -> Result<(Vec<u64>, &[u8]), ClubcardErro
     }));
 
     Ok((items, rest))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_len_rejects_oversized_lengths() {
+        let mut buf = Vec::new();
+        encode_len::<1>(u8::MAX as usize, &mut buf).unwrap();
+        assert_eq!(buf, [0xff]);
+        assert!(encode_len::<1>(u8::MAX as usize + 1, &mut Vec::new()).is_err());
+
+        let mut buf = Vec::new();
+        encode_len::<2>(u16::MAX as usize, &mut buf).unwrap();
+        assert_eq!(buf, [0xff, 0xff]);
+        assert!(encode_len::<2>(u16::MAX as usize + 1, &mut Vec::new()).is_err());
+    }
+
+    #[test]
+    fn index_entry_rejects_oversized_serial() {
+        let mut entry = ClubcardIndexEntry {
+            approx_filter_m: 0,
+            approx_filter_rank: 0,
+            approx_filter_offset: 0,
+            exact_filter_m: 0,
+            exact_filter_offset: 0,
+            inverted: false,
+            exceptions: vec![vec![0u8; u8::MAX as usize]],
+        };
+        entry.encode(&mut Vec::new()).unwrap();
+
+        entry.exceptions = vec![vec![0u8; u8::MAX as usize + 1]];
+        assert!(entry.encode(&mut Vec::new()).is_err());
+    }
+
+    #[test]
+    fn index_entry_rejects_oversized_exception_count() {
+        let mut entry = ClubcardIndexEntry {
+            approx_filter_m: 0,
+            approx_filter_rank: 0,
+            approx_filter_offset: 0,
+            exact_filter_m: 0,
+            exact_filter_offset: 0,
+            inverted: false,
+            exceptions: vec![Vec::new(); u16::MAX as usize],
+        };
+        entry.encode(&mut Vec::new()).unwrap();
+
+        entry.exceptions = vec![Vec::new(); u16::MAX as usize + 1];
+        assert!(entry.encode(&mut Vec::new()).is_err());
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#![warn(clippy::cast_possible_truncation)]
+
 #[cfg(feature = "builder")]
 pub mod builder;
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -235,6 +235,7 @@ impl AsQuery<W> for CRLiteQuery<'_> {
             a[i] = x;
         }
         a[0] |= 1;
+        #[allow(clippy::cast_possible_truncation)] // s is a usize, but we only need it to be a u32
         let s = (a[3] % (max(1, m) as u64)) as usize;
         Equation::homogeneous(s, a)
     }

--- a/src/query.rs
+++ b/src/query.rs
@@ -28,8 +28,9 @@ pub struct LogId(pub [u8; 32]);
 
 // opaque LogId[32]: a fixed-width 32-byte SHA-256 digest, no length prefix.
 impl Codec for LogId {
-    fn encode(&self, buf: &mut Vec<u8>) {
+    fn encode(&self, buf: &mut Vec<u8>) -> Result<(), ClubcardError> {
         buf.extend_from_slice(&self.0);
+        Ok(())
     }
 
     fn read(buf: &[u8]) -> Result<(Self, &[u8]), ClubcardError> {
@@ -52,8 +53,8 @@ impl Timestamp {
 
 // uint64 Timestamp, big-endian (see the u64 Codec impl).
 impl Codec for Timestamp {
-    fn encode(&self, buf: &mut Vec<u8>) {
-        self.0.encode(buf);
+    fn encode(&self, buf: &mut Vec<u8>) -> Result<(), ClubcardError> {
+        self.0.encode(buf)
     }
 
     fn read(buf: &[u8]) -> Result<(Self, &[u8]), ClubcardError> {
@@ -72,9 +73,9 @@ pub struct TimestampInterval {
 //     Timestamp high;
 // } TimestampInterval;
 impl Codec for TimestampInterval {
-    fn encode(&self, buf: &mut Vec<u8>) {
-        self.low.encode(buf);
-        self.high.encode(buf);
+    fn encode(&self, buf: &mut Vec<u8>) -> Result<(), ClubcardError> {
+        self.low.encode(buf)?;
+        self.high.encode(buf)
     }
 
     fn read(buf: &[u8]) -> Result<(Self, &[u8]), ClubcardError> {
@@ -100,12 +101,14 @@ impl CRLiteCoverage {
 //
 // Coverage coverage<count>;   // uint16 count, then `count` entries
 impl Codec for CRLiteCoverage {
-    fn encode(&self, buf: &mut Vec<u8>) {
-        encode_len::<2>(self.0.len(), buf);
+    fn encode(&self, buf: &mut Vec<u8>) -> Result<(), ClubcardError> {
+        encode_len::<2>(self.0.len(), buf)?;
         for (log_id, interval) in &self.0 {
-            log_id.encode(buf);
-            interval.encode(buf);
+            log_id.encode(buf)?;
+            interval.encode(buf)?;
         }
+
+        Ok(())
     }
 
     fn read(buf: &[u8]) -> Result<(Self, &[u8]), ClubcardError> {
@@ -130,12 +133,14 @@ impl Codec for CRLiteCoverage {
 //
 // IndexEntry index<count>;   // uint32 count, then `count` entries
 impl Codec for ClubcardIndex {
-    fn encode(&self, buf: &mut Vec<u8>) {
-        encode_len::<4>(self.len(), buf);
+    fn encode(&self, buf: &mut Vec<u8>) -> Result<(), ClubcardError> {
+        encode_len::<4>(self.len(), buf)?;
         for (block_id, entry) in self {
             buf.extend_from_slice(block_id);
-            entry.encode(buf);
+            entry.encode(buf)?;
         }
+
+        Ok(())
     }
 
     fn read(buf: &[u8]) -> Result<(Self, &[u8]), ClubcardError> {
@@ -387,13 +392,13 @@ impl CRLiteClubcard {
     /// Serialize this clubcard.
     pub fn to_bytes(&self, encoding: Encoding) -> Result<Vec<u8>, ClubcardError> {
         let mut out = Vec::with_capacity(2 + self.0.approximate_size_of());
-        encoding.encode(&mut out);
+        encoding.encode(&mut out)?;
 
         match encoding {
             #[cfg(feature = "bincode")]
             Encoding::V3 => bincode::serialize_into(&mut out, &self.0)
                 .map_err(|error| ClubcardError::Serialize(error.into()))?,
-            Encoding::V4 => self.0.encode(&mut out),
+            Encoding::V4 => self.0.encode(&mut out)?,
         }
 
         Ok(out)
@@ -467,9 +472,10 @@ pub enum Encoding {
 }
 
 impl Codec for Encoding {
-    fn encode(&self, buf: &mut Vec<u8>) {
+    fn encode(&self, buf: &mut Vec<u8>) -> Result<(), ClubcardError> {
         buf.push(*self as u8);
         buf.push(0); // reserved0
+        Ok(())
     }
 
     fn read(buf: &[u8]) -> Result<(Self, &[u8]), ClubcardError> {


### PR DESCRIPTION
Fixes #33. Oops!