### PR TITLE
Enforce block_id.len() == 32 while serializing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "clubcard-crlite"
 authors = ["John M. Schanck <jschanck@mozilla.com>"]
-version = "0.6.1"
+version = "0.6.2"
 license = "MPL-2.0"
 repository = "https://github.com/mozilla/clubcard-crlite/"
 description = "An instantiation of Clubcard for use in CRLite"

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -328,6 +328,45 @@ mod tests {
         assert!(entry.encode(&mut Vec::new()).is_err());
     }
 
+    #[cfg(target_pointer_width = "64")]
+    #[test]
+    fn index_entry_rejects_oversized_offset() {
+        let mut entry = ClubcardIndexEntry {
+            approx_filter_m: 0,
+            approx_filter_rank: 0,
+            approx_filter_offset: 0,
+            exact_filter_m: 0,
+            exact_filter_offset: u32::MAX as usize,
+            inverted: false,
+            exceptions: Vec::new(),
+        };
+        entry.encode(&mut Vec::new()).unwrap();
+
+        entry.exact_filter_offset = u32::MAX as usize + 1;
+        assert!(entry.encode(&mut Vec::new()).is_err());
+    }
+
+    #[test]
+    fn index_rejects_block_id_that_is_not_32_bytes() {
+        let entry = || ClubcardIndexEntry {
+            approx_filter_m: 0,
+            approx_filter_rank: 0,
+            approx_filter_offset: 0,
+            exact_filter_m: 0,
+            exact_filter_offset: 0,
+            inverted: false,
+            exceptions: Vec::new(),
+        };
+
+        let mut index = ClubcardIndex::new();
+        index.insert(vec![0u8; 32], entry());
+        index.encode(&mut Vec::new()).unwrap();
+
+        let mut index = ClubcardIndex::new();
+        index.insert(vec![0u8; 31], entry());
+        assert!(index.encode(&mut Vec::new()).is_err());
+    }
+
     #[test]
     fn index_entry_rejects_oversized_exception_count() {
         let mut entry = ClubcardIndexEntry {

--- a/src/query.rs
+++ b/src/query.rs
@@ -136,6 +136,13 @@ impl Codec for ClubcardIndex {
     fn encode(&self, buf: &mut Vec<u8>) -> Result<(), ClubcardError> {
         encode_len::<4>(self.len(), buf)?;
         for (block_id, entry) in self {
+            // Block ids are encoded without a length prefix, and read() takes them to be
+            // 32 byte issuer SPKI hashes. Anything else would desynchronize the reader.
+            if block_id.len() != 32 {
+                return Err(ClubcardError::Serialize(
+                    format!("block id has {} bytes, expected 32", block_id.len()).into(),
+                ));
+            }
             buf.extend_from_slice(block_id);
             entry.encode(buf)?;
         }


### PR DESCRIPTION
One more case where we're too lax in serializing.